### PR TITLE
add t tag for translated strings in templates

### DIFF
--- a/jekyll-multiple-languages.gemspec
+++ b/jekyll-multiple-languages.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name        = 'jekyll-multiple-languages'
-  s.version     = '1.0.6'
+  s.version     = '1.0.8'
   s.date        = '2014-08-15'
   s.summary     = "Another Multiple Languages Plugin for Jekyll!"
   s.description = ""

--- a/jekyll-multiple-languages.gemspec
+++ b/jekyll-multiple-languages.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
     "lib/jekyll-multiple-languages.rb",
     "lib/jekyll-multiple-languages/pager.rb",
     "lib/jekyll-multiple-languages/pagination.rb",
+    "lib/jekyll-multiple-languages/tags.rb",
   ]
   s.homepage    = 'http://jekyll-langs.liaohuqiu.net/'
   s.license      = 'MIT'

--- a/lib/jekyll-multiple-languages.rb
+++ b/lib/jekyll-multiple-languages.rb
@@ -1,5 +1,6 @@
 require "jekyll-multiple-languages/pager"
 require "jekyll-multiple-languages/pagination"
+require "jekyll-multiple-languages/tags"
 module Jekyll
   module MultiLang
     attr_accessor :language, :name_no_language, :is_default_language, :url_no_language, :dir_source, :next_in_language, :previous_in_language
@@ -151,6 +152,7 @@ module Jekyll
     def update_config(config)
       !config['languages'] && config['languages'] = []
       !config['language_default'] && config['language_default'] = config['languages'].first;
+      !config['i18ndir'] && config['i18ndir'] = "_i18n";
 
       %w[languages language_default fill_default_content].each do |opt|
         self.send("#{opt}=", config[opt])

--- a/lib/jekyll-multiple-languages/tags.rb
+++ b/lib/jekyll-multiple-languages/tags.rb
@@ -1,0 +1,55 @@
+module Jekyll
+  @translations={}
+  def self.translations
+        @translations
+  end
+
+  class LocalizeTag < Liquid::Tag
+
+    def initialize(tag_name, key, tokens)
+      super
+      @key = key.strip
+    end
+
+    def render(context)
+      if "#{context[@key]}" != "" #Check for page variable
+        key = "#{context[@key]}"
+      else
+        key = @key
+      end
+      lang = context.registers[:page]['language']
+      unless Jekyll.translations.has_key?(lang)
+        translationfile="#{context.registers[:site].source}/#{context.registers[:site].config['i18ndir']}/#{lang}.yml"
+        puts "Loading translation from file #{translationfile}"
+        Jekyll.translations[lang] = YAML.load_file(translationfile)
+      end
+      translation = Jekyll.translations[lang].access(key) if key.is_a?(String)
+      if translation.nil? or translation.empty?
+        translation = Jekyll.translations[context.registers[:site].config['language_default']].access(key)
+        puts "Missing i18n key: #{lang}:#{key}"
+        puts "Using translation '%s' from default language: %s" %[translation, context.registers[:site].config['language_default']]
+      end
+      translation
+    end
+  end
+end
+
+unless Hash.method_defined? :access
+  class Hash
+    def access(path)
+      ret = self
+      path.split('.').each do |p|
+        if p.to_i.to_s == p
+          ret = ret[p.to_i]
+        else
+          ret = ret[p.to_s] || ret[p.to_sym]
+        end
+        break unless ret
+      end
+      ret
+    end
+  end
+end
+
+Liquid::Template.register_tag('t', Jekyll::LocalizeTag)
+Liquid::Template.register_tag('translate', Jekyll::LocalizeTag)


### PR DESCRIPTION
I needed the t function for my templates.
This code is highly inspired (partwise direct copy) by https://github.com/screeninteraction/jekyll-multiple-languages-plugin They use the Mozilla public license.
As I understand it at least the newly intruduced file must be under MPL.
If you don't agree with this I can rewrite the code from scratch.